### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,65 @@
 # vpptop
 
-Introduction
-============
+The `vpptop` is a Go implementation of real-time viewer for VPP metrics provided by dynamic terminal user interface ([TUI][wiki-tui]).
 
-This is `vpptop`, a terminal only application implemented in Go.
-The goal of vpptop is to provide VPP statistics which are updated
-in real time.
+[![asciicast](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R.svg)](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R)
 
-The current version 1.11 supports statistics for:
- 1. interfaces
- 2. nodes
- 3. errors
- 4. memory usage per thread
- 5. thread data
- 
- [![asciicast](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R.svg)](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R)
+## Features
 
-Install
-====== 
-In order to run vpptop you will need to install the dependencies
-first.
-1. [termui-go](https://github.com/gizak/termui). ``go get github.com/gizak/termui``<br>
-3. [GoVPP](https://github.com/FDio/govpp). ``go get git.fd.io/govpp.git``<br>
+Following VPP metrics are currently supported:
 
-If you run into some problems with installing a dependency we suggest you read<br>
-their ``README.md`` file which you can find in the links provided above.
+ - **Interface stats** - RX/TX packets/bytes, packet errors/drops/punts/IPv4..
+ - **Node stats** - clocks, vectors, calls, suspends..
+ - **Error counters** - node, reason
+ - **Memory usage** - free, used..
+ - **Thread info** - name, type, PID..
 
+## Install
 
-You will also need [VPP](https://github.com/FDio/vpp) with version at least 19.04-6. You can read about the <br>
-installation process here <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>.
+### Requirements
 
-After installing the dependencies you can run the application from the parent directory. <br>
-You may need root access.<br>
-``sudo go run ./govpp-statsviewer/``
+In order to install and run vpptop you need to install following requirements:
 
-NOTE:// Interfaces and Node names will not be displayed with VPP version below 19.04-6,
-which is the result of adding [version-ing](https://github.com/FDio/govpp/blob/master/adapter/vppapiclient/stat_client_wrapper.h#L29) for the GoVPP stats-api <br>
+ - [Go](https://golang.org/dl/)
+ - [VPP](https://wiki.fd.io/view/VPP) 19.04
 
-Binary API
-=============
-<b>This step is not needed to run ``GoVPP stats-viewer``<br>Read this section only if you need to rebuild the binary APIs. <br>:For example if you
-want to run stats-viewer on a different VPP version.</b>
+### Install VPP
 
-You will need to install the ``binapi-generator`` in your $GOPATH. You can find the process of <br>
-the installation here <https://github.com/FDio/govpp>.
+For instructions of how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
 
-In go, [go generate](https://blog.golang.org/generate) tool can be used to generate Go bindings from VPP APis in JSON format. <br>
-You can generate the bindigs from the root directory of the project using the command ``go generate``.
+:warning: For full support of interface/node names in vpptop, the VPP version has to be `19.04-3~g1cb333cdf~b41` or newer. The release version of VPP 19.04 will not work, because [stats API versioning][stats-version-commit] was added after the release of VPP 19.04 (it was backported to _stable/1904_ branch).
 
-By default it will use the JSON files stored in ``/usr/share/vpp/api/core/`` and will generate the output <br>
-in the root directory of the project inside the ``bin_api`` directory.
+> NOTE: When installing VPP from packagecloud using [FDio's 1904 repository](https://packagecloud.io/fdio/1904), using `apt-get install vpp` will NOT install the correct VPP version. This is because the order of versions in this repository is not correct.  To install correct VPP version, you should specify version you want install, e.g. `apt-get install vpp=19.04-3~g1cb333cdf~b41`.
 
-In case you need to use different JSON files you can change it in the ``gen.go`` file.
-Where you can specify <br> the input directory of the JSON files and where the bindings should be generated.
+### Install vpptop
 
-``//go:generate binapi-generator --input-dir=/usr/share/vpp/api/core/ --output-dir=bin_api``
+To install vpptop run the following command:
 
-Usage
-====
+```sh
+# this will install vpptop to $GOPATH/bin
+$ go get -u github.com/PantheonTechnologies/vpptop
+```
 
-Keybindings:
+The VPP should have enabled stats API. To enable stats API add [`statseg` section](https://wiki.fd.io/view/VPP/Command-line_Arguments#statseg_.7B_..._.7D) to your VPP startup config. 
+
+```
+# this will use /run/vpp/stats.sock for stats socket
+statsseg {
+	default
+}
+```
+
+### Run vpptop
+
+The VPP should be running before starting vpptop. To start vpptop run following command:
+
+```sh
+$ sudo vpptop
+# sudo might be required, due stats socket file permissions
+```
+
+### Keybindings
+
 1. Keyboard arrows ``Up, Down, Left, Right`` to switch tabs, scroll.
 2. ``Crtl-Space`` open/close menu for sort by column for the active table.
 3. ``/`` to filter the active table.
@@ -67,3 +67,28 @@ Keybindings:
 5. ``PgDn PgUp`` to skip pages in active table.
 6. ``Ctrl-C`` to clear counters for the active table.
 7. ``q`` to quit from the application
+
+## Developing vpptop
+
+This section provides information about vpptop development.
+
+### VPP binary API
+
+> NOTE: This step is not needed for running vpptop!
+
+The vpptop uses GoVPP's binapi-generator to generate Go bindings for VPP binary API from JSON format. This should not normally be needed unless you want to use vpptop with different VPP version that has changed it's API.
+
+For installation instructions for GoVPP's binapi-generator, see: <https://github.com/FDio/govpp/blob/master/README.md>
+
+The vpptop uses [go generate](https://blog.golang.org/generate) tool to actually run the binapi-generator. To run the generator simply go to the vpptop directory and run: `go generate`.
+
+```go
+//go:generate binapi-generator --input-dir=/usr/share/vpp/api/core/ --output-dir=bin_api
+```
+
+By default it will use the JSON files stored in `/usr/share/vpp/api/core/` that are installed together with VPP and outputs the generated files to `bin_api` directory.
+
+In case you need to use different JSON files you can change the arguments in the `gen.go` file, where you can specify the input directory of the JSON files and where the bindings should be generated.
+
+[wiki-tui]: https://en.wikipedia.org/wiki/Text-based_user_interface
+[stats-version-commit]: https://github.com/FDio/vpp/commit/1cb333cdf5ce26557233c5bdb5a18738cb6e1e2c

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ statsseg {
 }
 ```
 
-## Install vpptop
+## Install & Run vpptop
 
 To install vpptop run the following command:
 
@@ -53,13 +53,11 @@ To install vpptop run the following command:
 $ go get -u github.com/PantheonTechnologies/vpptop
 ```
 
-## Run vpptop
-
 To start vpptop run following command:
 
 ```sh
-$ sudo vpptop
-# sudo might be required, due stats socket file permissions
+$ sudo -E vpptop
+# sudo might be required, because of permissions to stats socket file
 ```
 
 NOTE: The VPP should be running before starting vpptop!

--- a/README.md
+++ b/README.md
@@ -25,13 +25,24 @@ In order to install and run vpptop you need to install following requirements:
  - [Go](https://golang.org/dl/) 1.11+
  - [VPP](https://wiki.fd.io/view/VPP) (`19.04-3~g1cb333cdf~b41` is recommended, more info below)
 
-### Installing VPP
+### Install VPP
 
 For instructions of how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
 
 :warning: For full support of interface/node names in vpptop, the VPP version has to be `19.04-3~g1cb333cdf~b41` or newer. The release version of VPP 19.04 will not work, because [stats API versioning][stats-version-commit] was added after the release of VPP 19.04 (it was backported to _stable/1904_ branch).
 
 > NOTE: When installing VPP from packagecloud using [FDio's 1904 repository](https://packagecloud.io/fdio/1904), using `apt-get install vpp` will NOT install the correct VPP version. This is because the order of versions in this repository is not correct.  To install correct VPP version, you should specify version you want install, e.g. `apt-get install vpp=19.04-3~g1cb333cdf~b41`.
+
+### Configure VPP
+
+The vpptop uses VPP stats API for retrieving statistics. The VPP stats API is disabled by default and to enable it, add [`statseg` section](https://wiki.fd.io/view/VPP/Command-line_Arguments#statseg_.7B_..._.7D) to your VPP config, like this:
+
+```
+# this will use /run/vpp/stats.sock for stats socket
+statsseg {
+	default
+}
+```
 
 ## Install vpptop
 
@@ -42,23 +53,16 @@ To install vpptop run the following command:
 $ go get -u github.com/PantheonTechnologies/vpptop
 ```
 
-The VPP should have enabled stats API. To enable stats API add [`statseg` section](https://wiki.fd.io/view/VPP/Command-line_Arguments#statseg_.7B_..._.7D) to your VPP startup config. 
-
-```
-# this will use /run/vpp/stats.sock for stats socket
-statsseg {
-	default
-}
-```
-
 ## Run vpptop
 
-The VPP should be running before starting vpptop. To start vpptop run following command:
+To start vpptop run following command:
 
 ```sh
 $ sudo vpptop
 # sudo might be required, due stats socket file permissions
 ```
+
+NOTE: The VPP should be running before starting vpptop!
 
 ### Keybindings
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,9 @@ $ sudo vpptop
 
 ## Developing vpptop
 
-This section provides information about vpptop development.
+This section is **not required** for running vpptop and provides information for development of vpptop.
 
 ### VPP binary API
-
-> NOTE: This step is not needed for running vpptop!
 
 The vpptop uses GoVPP's binapi-generator to generate Go bindings for VPP binary API from JSON format. This should not normally be needed unless you want to use vpptop with different VPP version that has changed it's API.
 
@@ -91,6 +89,7 @@ The vpptop uses [go generate](https://blog.golang.org/generate) tool to actually
 By default it will use the JSON files stored in `/usr/share/vpp/api/core/` that are installed together with VPP and outputs the generated files to `bin_api` directory.
 
 In case you need to use different JSON files you can change the arguments in the `gen.go` file, where you can specify the input directory of the JSON files and where the bindings should be generated.
+
 
 [wiki-tui]: https://en.wikipedia.org/wiki/Text-based_user_interface
 [stats-version-commit]: https://github.com/FDio/vpp/commit/1cb333cdf5ce26557233c5bdb5a18738cb6e1e2c

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Following VPP stats are currently supported:
 In order to install and run vpptop you need to install following requirements:
 
  - [Go](https://golang.org/dl/) 1.11+
- - [VPP](https://wiki.fd.io/view/VPP) 19.04
+ - [VPP](https://wiki.fd.io/view/VPP) (`19.04-3~g1cb333cdf~b41` is recommended, more info below)
 
 ### Install VPP
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For instructions of how to install VPP from packages, see: <https://wiki.fd.io/v
 
 The vpptop uses VPP stats API for retrieving statistics. The VPP stats API is disabled by default and to enable it, add [`statseg` section](https://wiki.fd.io/view/VPP/Command-line_Arguments#statseg_.7B_..._.7D) to your VPP config, like this:
 
-```
+```sh
 # this will use /run/vpp/stats.sock for stats socket
 statsseg {
 	default

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # vpptop
 
-The `vpptop` is a Go implementation of real-time viewer for VPP metrics provided by dynamic terminal user interface ([TUI][wiki-tui]).
+The **vpptop** is a Go implementation of real-time viewer for VPP metrics provided by dynamic terminal user interface.
 
-[![asciicast](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R.svg)](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R)
+## Preview
+
+Below is short demo preview of **vpptop** in action.
+
+[![preview](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R.svg)](https://asciinema.org/a/NHODZM2ebcwWFPEEPcja8X19R)
 
 ## Features
 
-Following VPP metrics are currently supported:
+Following VPP stats are currently supported:
 
  - **Interface stats** - RX/TX packets/bytes, packet errors/drops/punts/IPv4..
  - **Node stats** - clocks, vectors, calls, suspends..

--- a/README.md
+++ b/README.md
@@ -18,16 +18,14 @@ Following VPP stats are currently supported:
  - **Memory usage** - free, used..
  - **Thread info** - name, type, PID..
 
-## Install
-
-### Requirements
+## Requirements
 
 In order to install and run vpptop you need to install following requirements:
 
  - [Go](https://golang.org/dl/) 1.11+
  - [VPP](https://wiki.fd.io/view/VPP) (`19.04-3~g1cb333cdf~b41` is recommended, more info below)
 
-### Install VPP
+### Installing VPP
 
 For instructions of how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
 
@@ -35,7 +33,7 @@ For instructions of how to install VPP from packages, see: <https://wiki.fd.io/v
 
 > NOTE: When installing VPP from packagecloud using [FDio's 1904 repository](https://packagecloud.io/fdio/1904), using `apt-get install vpp` will NOT install the correct VPP version. This is because the order of versions in this repository is not correct.  To install correct VPP version, you should specify version you want install, e.g. `apt-get install vpp=19.04-3~g1cb333cdf~b41`.
 
-### Install vpptop
+## Install vpptop
 
 To install vpptop run the following command:
 
@@ -53,7 +51,7 @@ statsseg {
 }
 ```
 
-### Run vpptop
+## Run vpptop
 
 The VPP should be running before starting vpptop. To start vpptop run following command:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ In order to install and run vpptop you need to install following requirements:
 
 ### Install VPP
 
-For instructions of how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
+To install VPP from packagecloud on Ubuntu 18.04, run following commands:
+
+```sh
+curl -s https://packagecloud.io/install/repositories/fdio/1904/script.deb.sh | sudo bash
+sudo apt-get install -y vpp vpp-dev vpp-plugin-core
+```
+
+For more info about how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
 
 :warning: For full support of interface/node names in vpptop, the VPP version has to be `19.04-3~g1cb333cdf~b41` or newer. The release version of VPP 19.04 will not work, because [stats API versioning][stats-version-commit] was added after the release of VPP 19.04 (it was backported to _stable/1904_ branch).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# vpptop
+vpptop
+======
 
 The **vpptop** is a Go implementation of real-time viewer for VPP metrics provided by dynamic terminal user interface.
 
@@ -30,8 +31,6 @@ In order to install and run vpptop you need to install following requirements:
 For instructions of how to install VPP from packages, see: <https://wiki.fd.io/view/VPP/Installing_VPP_binaries_from_packages>
 
 :warning: For full support of interface/node names in vpptop, the VPP version has to be `19.04-3~g1cb333cdf~b41` or newer. The release version of VPP 19.04 will not work, because [stats API versioning][stats-version-commit] was added after the release of VPP 19.04 (it was backported to _stable/1904_ branch).
-
-> NOTE: When installing VPP from packagecloud using [FDio's 1904 repository](https://packagecloud.io/fdio/1904), using `apt-get install vpp` will NOT install the correct VPP version. This is because the order of versions in this repository is not correct.  To install correct VPP version, you should specify version you want install, e.g. `apt-get install vpp=19.04-3~g1cb333cdf~b41`.
 
 ### Configure VPP
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Following VPP stats are currently supported:
 
 In order to install and run vpptop you need to install following requirements:
 
- - [Go](https://golang.org/dl/)
+ - [Go](https://golang.org/dl/) 1.11+
  - [VPP](https://wiki.fd.io/view/VPP) 19.04
 
 ### Install VPP


### PR DESCRIPTION
- [x] remove steps related to installing Go dependencies (it's managed by Go using `go.mod`)
- [x] define exact version of VPP in which the stats API versioning was added
- [x] mention VPP config section `statseg` for enabling stats socket
- [x] remove mentions of `govpp-statsviewer`
- [x] cleanup structure and improve formatting