### PR TITLE
mod typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The vpptop uses VPP stats API for retrieving statistics. The VPP stats API is di
 
 ```sh
 # this will use /run/vpp/stats.sock for stats socket
-statsseg {
+statseg {
 	default
 }
 ```


### PR DESCRIPTION
Fix typo startup.conf example in README.md which didn't work.